### PR TITLE
feat: implement token management with async-mutex for API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@twilio/conversations": "^2.6.2",
         "@types/uuid": "^10.0.0",
         "@zegocloud/zego-uikit-prebuilt": "^2.14.3-beta",
+        "async-mutex": "^0.4.1",
         "axios": "^1.8.4",
         "babel-plugin-react-compiler": "^19.0.0-beta-df7b47d-20241124",
         "bufferutil": "^4.0.9",
@@ -4770,6 +4771,15 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "utf-8-validate": "^5.0.10",
     "uuid": "^11.1.0",
     "yarn": "^1.22.22",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "async-mutex": "^0.4.1"
   },
   "devDependencies": {
     "@types/js-cookie": "^3.0.6",

--- a/src/components/layouts/auth/login-form.tsx
+++ b/src/components/layouts/auth/login-form.tsx
@@ -19,6 +19,7 @@ import { toast } from "sonner";
 import constants from "@/config/constants";
 import { useTranslations } from "next-intl";
 import { useEditUpdateAtMutation } from "@/api/ProfileApi";
+import { setClientCookie } from "@/utils/jsCookies";
 
 export function LoginForm() {
   const router = useRouter();
@@ -45,6 +46,12 @@ export function LoginForm() {
         if (payload.result) {
           const { accessToken, roleName } = payload.result as LoginResponseDTO;
           await editUpdateAt({ email });
+          // Set token with expiry
+          setClientCookie('accessToken', accessToken, {
+            expires: rememberMe ? 30 : 1, // 30 days if remember me, 1 day if not
+            secure: true,
+            sameSite: 'strict'
+          });
           if (accessToken && roleName == "ADMIN") {
             router.push("/admin");
           } else {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,14 @@
-import { getClientCookie } from "@/utils/jsCookies";
+import { getClientCookie, setClientCookie, deleteClientCookie } from "@/utils/jsCookies";
 import constants from "@/config/constants";
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { createApi, fetchBaseQuery, BaseQueryFn } from "@reduxjs/toolkit/query/react";
+import { Mutex } from 'async-mutex';
+
+interface RefreshResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+const mutex = new Mutex();
 
 const baseQuery = fetchBaseQuery({
   baseUrl: constants.API_SERVER,
@@ -17,8 +25,56 @@ const baseQuery = fetchBaseQuery({
   },
 });
 
+const baseQueryWithReauth: BaseQueryFn = async (args, api, extraOptions) => {
+  await mutex.waitForUnlock();
+  let result = await baseQuery(args, api, extraOptions);
+
+  if (result.error && result.error.status === 401) {
+    if (!mutex.isLocked()) {
+      const release = await mutex.acquire();
+      try {
+        const refreshToken = getClientCookie("refreshToken");
+        if (!refreshToken) {
+          deleteClientCookie("accessToken");
+          deleteClientCookie("refreshToken");
+          window.location.href = "/login";
+          return result;
+        }
+
+        const refreshResult = await baseQuery(
+          {
+            url: "/api/auth/refresh-token",
+            method: "POST",
+            body: { refreshToken },
+          },
+          api,
+          extraOptions
+        );
+
+        if (refreshResult.data) {
+          const { accessToken, refreshToken: newRefreshToken } = refreshResult.data as RefreshResponse;
+          setClientCookie("accessToken", accessToken, { expires: 1 });
+          setClientCookie("refreshToken", newRefreshToken, { expires: 30 });
+          result = await baseQuery(args, api, extraOptions);
+        } else {
+          deleteClientCookie("accessToken");
+          deleteClientCookie("refreshToken");
+          window.location.href = "/login";
+        }
+      } finally {
+        release();
+      }
+    } else {
+      await mutex.waitForUnlock();
+      result = await baseQuery(args, api, extraOptions);
+    }
+  }
+
+  return result;
+};
+
 export const baseApi = createApi({
-  baseQuery: baseQuery,
+  baseQuery: baseQueryWithReauth,
   tagTypes: ['Meeting', 'Recording', 'Translation'],
   endpoints: () => ({}),
 });

--- a/src/utils/jsCookies.ts
+++ b/src/utils/jsCookies.ts
@@ -1,12 +1,23 @@
 import Cookies from "js-cookie";
 
+interface CookieOptions {
+  expires?: number; // days
+  secure?: boolean;
+  sameSite?: 'strict' | 'lax' | 'none';
+}
+
 /**
- * Set a cookie.
+ * Set a cookie with options.
  * @param name - The name of the cookie.
  * @param value - The value of the cookie.
+ * @param options - Cookie options (expires in days, secure, sameSite)
  */
-export const setClientCookie = (name: string, value: string): void => {
-  Cookies.set(name, value);
+export const setClientCookie = (name: string, value: string, options?: CookieOptions): void => {
+  Cookies.set(name, value, {
+    expires: options?.expires || 1, // Default 1 day
+    secure: options?.secure || true, // Default true
+    sameSite: options?.sameSite || 'strict' // Default strict
+  });
 };
 
 /**


### PR DESCRIPTION
- Added async-mutex to handle concurrent API requests and prevent race conditions during token refresh.
- Updated base query to include reauthentication logic, managing access and refresh tokens securely.
- Enhanced cookie management with options for expiration, security, and same-site attributes.
- Integrated token setting in the login form to ensure proper session handling.